### PR TITLE
Extract BackLink component to eliminate duplicated back-navigation markup

### DIFF
--- a/src/components/BackLink/index.tsx
+++ b/src/components/BackLink/index.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+import Link from 'next/link'
+
+type Props = {
+  href: string
+  label: string
+}
+
+export default function BackLink({ href, label }: Props) {
+  return (
+    <Link href={href} passHref>
+      <a className="leading-snug text-tertiary hover:text-gray-1000 dark:hover:text-gray-100">
+        &larr; {label}
+      </a>
+    </Link>
+  )
+}

--- a/src/components/Bookmarks/Page.tsx
+++ b/src/components/Bookmarks/Page.tsx
@@ -7,7 +7,7 @@ import AddBookmark from '~/components/Bookmarks/AddBookmark'
 import { CenteredColumn } from '~/components/Layouts'
 import BookmarksNavigation from '~/components/Bookmarks/BookmarksNavigation'
 import routes from '~/config/routes'
-import Link from 'next/link'
+import BackLink from '~/components/BackLink'
 
 export default function BookmarksPage({ category }) {
   const { isMe } = useAuth()
@@ -22,11 +22,7 @@ export default function BookmarksPage({ category }) {
 
       <CenteredColumn>
         <div data-cy="bookmarks" className="space-y-8">
-          <Link href="/projects" passHref>
-            <a className="leading-snug text-tertiary hover:text-gray-1000 dark:hover:text-gray-100">
-              &larr; Projects
-            </a>
-          </Link>
+          <BackLink href="/projects" label="Projects" />
           <PageHeader
             title="Bookmarks"
             subtitle="Internet masterpieces that I'm constantly referencing'."

--- a/src/components/DesignDetailView/index.tsx
+++ b/src/components/DesignDetailView/index.tsx
@@ -6,7 +6,7 @@ import { DesignDetailsPost } from '~/data/appDissections'
 import { CenteredColumn } from '../Layouts'
 import { PageHeader } from '../Page'
 import Image from 'next/image'
-import Link from 'next/link'
+import BackLink from '~/components/BackLink'
 import WritingSubscribeBox from '../Writing/Subscribe'
 
 interface Props {
@@ -23,11 +23,7 @@ export default function DesignDetailView(props: Props) {
   return (
     <CenteredColumn>
       <div className="space-y-8">
-        <Link href="/app-dissection" passHref>
-          <a className="leading-snug text-tertiary hover:text-gray-1000 dark:hover:text-gray-100">
-            &larr; App Dissection
-          </a>
-        </Link>
+        <BackLink href="/app-dissection" label="App Dissection" />
 
         <div className="flex items-center space-x-4">
           <Image

--- a/src/components/Writing/Post/index.tsx
+++ b/src/components/Writing/Post/index.tsx
@@ -4,7 +4,7 @@ import WritingSubscribeBox from '~/components/Writing/Subscribe'
 import SyntaxHighlighter from '~/components/SyntaxHighlighter'
 import SEO from './SEO'
 import { CenteredColumn } from '~/components/Layouts'
-import Link from 'next/link'
+import BackLink from '~/components/BackLink'
 
 interface Props {
   post: Post
@@ -24,11 +24,7 @@ export default function PostView({ post }: Props) {
 
       <CenteredColumn>
         <div data-cy="post" className="space-y-8 ">
-          <Link href="/writing" passHref>
-            <a className="leading-snug text-tertiary hover:text-gray-1000 dark:hover:text-gray-100">
-              &larr; Writing
-            </a>
-          </Link>
+          <BackLink href="/writing" label="Writing" />
           <div className="space-y-4">
             <h1 className="font-sans text-2xl font-extrabold md:text-4xl text-primary">
               {post.title}

--- a/src/pages/app-dissection/index.tsx
+++ b/src/pages/app-dissection/index.tsx
@@ -5,7 +5,7 @@ import DesignDetailsGrid from '~/components/DesignDetailsGrid'
 import { summaries } from '~/data/appDissections'
 import { CenteredColumn } from '~/components/Layouts'
 import routes from '~/config/routes'
-import Link from 'next/link'
+import BackLink from '~/components/BackLink'
 
 export default function DesignDetails() {
   return (
@@ -18,11 +18,7 @@ export default function DesignDetails() {
 
       <CenteredColumn>
         <div className="space-y-8 ">
-          <Link href="/projects" passHref>
-            <a className="leading-snug text-tertiary hover:text-gray-1000 dark:hover:text-gray-100">
-              &larr; Projects
-            </a>
-          </Link>
+          <BackLink href="/projects" label="Projects" />
 
           <PageHeader
             title="App Dissection"

--- a/src/pages/stack.tsx
+++ b/src/pages/stack.tsx
@@ -6,7 +6,7 @@ import { withApollo } from '~/components/withApollo'
 import { CenteredColumn } from '~/components/Layouts'
 import Recommendations from '~/components/Stack/Recommendations'
 import routes from '~/config/routes'
-import Link from 'next/link'
+import BackLink from '~/components/BackLink'
 
 function Stack() {
   return (
@@ -19,11 +19,7 @@ function Stack() {
 
       <CenteredColumn>
         <div className="space-y-8">
-          <Link href="/projects" passHref>
-            <a className="leading-snug text-tertiary hover:text-gray-1000 dark:hover:text-gray-100">
-              &larr; Projects
-            </a>
-          </Link>
+          <BackLink href="/projects" label="Projects" />
           <PageHeader
             title="Stack"
             subtitle="My favorite tools and software."


### PR DESCRIPTION
Five files had identical Link+anchor markup with the same className for back navigation. Extracted into a reusable BackLink component with href and label props.

https://claude.ai/code/session_01PSPQxJs9jqD234u9qf3hDJ